### PR TITLE
Add CI workflow to run dotnet tests

### DIFF
--- a/.github/workflows/dotnet-tests.yml
+++ b/.github/workflows/dotnet-tests.yml
@@ -1,0 +1,33 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Restore dependencies
+        run: dotnet restore ToyIncrementalParser.sln
+
+      - name: Build
+        run: dotnet build ToyIncrementalParser.sln --no-restore --configuration Release
+
+      - name: Test
+        run: dotnet test ToyIncrementalParser.sln --no-build --configuration Release --verbosity normal
+


### PR DESCRIPTION
- run dotnet restore/build/test for the solution in GitHub Actions
- check pulls and pushes to main with .NET 8
- enable the Tests status check in branch protection to gate merges

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a GitHub Actions workflow that restores, builds, and tests the solution with .NET 8 on pushes to main and pull requests.
> 
> - **CI / GitHub Actions**:
>   - **Workflow**: Add `.github/workflows/dotnet-tests.yml` to run tests on `push` to `main` and on `pull_request`.
>   - **Environment**: `ubuntu-latest`, `.NET 8.0.x` via `actions/setup-dotnet@v4`.
>   - **Pipeline**:
>     - Checkout repo.
>     - Restore `ToyIncrementalParser.sln`.
>     - Build in `Release` (`--no-restore`).
>     - Test in `Release` (`--no-build`, normal verbosity).
>   - **Permissions**: `contents: read`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a808142e878d56609eb0060374a35f1387019634. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->