### PR TITLE
Move statement list crumbling into parser.

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ The result is a stack where symbols appear in left-to-right order when popped, w
 
 ### The Parser's Reuse API
 
-The Parser uses two methods from `ISymbolStream` to request nonterminals for reuse:
+The Parser uses three methods from `ISymbolStream` to request nonterminals for reuse:
 
 1. **`TryPeekNonTerminal(out NodeKind kind, out GreenNode node)`**: Peeks at the top nonterminal on the stack without consuming it. This allows the parser to check what's available before deciding whether to reuse it.
 
@@ -192,6 +192,8 @@ The Parser uses two methods from `ISymbolStream` to request nonterminals for reu
    - The position is synchronized (the top nonterminal starts at `_currentPosition`)
    - The nonterminal's kind matches the requested kind
    - The nonterminal has no diagnostics (nodes with diagnostics are always rescanned)
+
+3. **`Crumble()`**: Crumbles the top nonterminal into its immediate children, which become available for reuse or lexing. This is only valid when the next symbol is a nonterminal (callers use `TryPeekNonTerminal` to check).
 
 The parser calls `TryReuseStatement` at the start of `ParseStatement` and in the loop in `ParseStatementList`, before checking what token comes next. This ensures that if a statement is available for reuse, it's taken before the parser would otherwise start parsing tokens, avoiding unnecessary crumbling.
 

--- a/ToyIncrementalParser/Parser/Blender.cs
+++ b/ToyIncrementalParser/Parser/Blender.cs
@@ -89,8 +89,8 @@ internal sealed class Blender : ISymbolStream
     /// <summary>
     /// Attempts to peek a reusable nonterminal at the top of the stack without
     /// consuming it. Only returns nonterminals that are synchronized and have
-    /// no diagnostics; nodes that contain diagnostics or statement lists are
-    /// crumbled to expose smaller reusable units.
+    /// no diagnostics; nodes that contain diagnostics are crumbled to expose
+    /// smaller reusable units.
     /// </summary>
     public bool TryPeekNonTerminal(out NodeKind kind, out GreenNode node)
     {
@@ -124,8 +124,8 @@ internal sealed class Blender : ISymbolStream
             // If it isn't, that's a bug
             AssertPositionSynchronized("TryPeekNonTerminal");
 
-            // If the non-terminal contains diagnostics or is a statement list, crumble it and try again
-            if (top.Node.ContainsDiagnostics || top.Node.Kind == NodeKind.StatementList)
+            // If the non-terminal contains diagnostics, crumble it and try again
+            if (top.Node.ContainsDiagnostics)
             {
                 CrumbleTopSymbol();
                 continue;
@@ -195,6 +195,28 @@ internal sealed class Blender : ISymbolStream
             AssertPositionSynchronized("TryTakeNonTerminal (before crumbling)");
             CrumbleTopSymbol();
         }
+    }
+
+    public void Crumble()
+    {
+        if (_peekedToken != null && _peekedTokenPopped)
+        {
+            throw new InvalidOperationException("Cannot crumble while a peeked token is pending.");
+        }
+
+        if (_symbolStack.Count == 0)
+        {
+            throw new InvalidOperationException("Cannot crumble an empty symbol stack.");
+        }
+
+        var top = _symbolStack.Peek();
+        if (top.IsText || top.Node is GreenToken)
+        {
+            throw new InvalidOperationException("Crumble is only valid when the next symbol is a nonterminal.");
+        }
+
+        AssertPositionSynchronized("Crumble");
+        CrumbleTopSymbol();
     }
 
     // Core character access methods used by BlenderCharacterSource

--- a/ToyIncrementalParser/Parser/ISymbolStream.cs
+++ b/ToyIncrementalParser/Parser/ISymbolStream.cs
@@ -3,13 +3,36 @@ using ToyIncrementalParser.Syntax.Green;
 
 namespace ToyIncrementalParser.Parser;
 
+/// <summary>
+/// Provides a token/nonterminal stream that supports incremental reuse and crumbling.
+/// </summary>
 internal interface ISymbolStream
 {
+    /// <summary>
+    /// Peeks the next token without consuming it.
+    /// </summary>
     SymbolToken PeekToken();
 
+    /// <summary>
+    /// Consumes and returns the next token.
+    /// </summary>
     SymbolToken ConsumeToken();
 
+    /// <summary>
+    /// Attempts to peek the next nonterminal without consuming it. Returns true only
+    /// when the next symbol is a synchronized nonterminal without diagnostics.
+    /// </summary>
     bool TryPeekNonTerminal(out NodeKind kind, out GreenNode node);
 
+    /// <summary>
+    /// Attempts to consume a nonterminal of the specified kind from the stream.
+    /// Succeeds only when the next symbol is a matching nonterminal without diagnostics.
+    /// </summary>
     bool TryTakeNonTerminal(NodeKind kind, out GreenNode node);
+
+    /// <summary>
+    /// Crumbles the next nonterminal into its immediate children, making them
+    /// available for reuse or lexing. Only valid when the next symbol is a nonterminal.
+    /// </summary>
+    void Crumble();
 }

--- a/ToyIncrementalParser/Parser/LexingSymbolStream.cs
+++ b/ToyIncrementalParser/Parser/LexingSymbolStream.cs
@@ -1,3 +1,4 @@
+using System;
 using ToyIncrementalParser.Syntax;
 using ToyIncrementalParser.Syntax.Green;
 using ToyIncrementalParser.Text;
@@ -49,5 +50,10 @@ internal sealed class LexingSymbolStream : ISymbolStream
     {
         node = null!;
         return false;
+    }
+
+    public void Crumble()
+    {
+        throw new InvalidOperationException("LexingSymbolStream does not support crumbling.");
     }
 }

--- a/ToyIncrementalParser/Parser/Parser.cs
+++ b/ToyIncrementalParser/Parser/Parser.cs
@@ -36,8 +36,15 @@ public sealed class Parser
         var statements = new List<GreenNode>();
         while (true)
         {
-            // Try to reuse a statement, before checking IsAtEnd() or PeekToken.Kind
-            // This avoids crumbling non-terminals when PeekToken() is called
+            if (_stream.TryPeekNonTerminal(out var kind, out _) &&
+                kind == NodeKind.StatementList &&
+                _stream.TryTakeNonTerminal(kind, out var listNode))
+            {
+                var statementList = (GreenStatementListNode)listNode;
+                statements.AddRange(statementList.Statements);
+                continue;
+            }
+
             if (TryReuseStatement(out var reused))
             {
                 statements.Add(reused);
@@ -54,6 +61,7 @@ public sealed class Parser
             var statement = ParseStatement();
             statements.Add(statement);
 
+            // If we're not making progress, break out of the loop
             if (ReferenceEquals(statementStart, PeekToken))
                 break;
         }
@@ -473,20 +481,15 @@ public sealed class Parser
     {
         statement = null!;
 
-        // Peek at the top non-terminal to see if it's a statement we can reuse
-        if (_stream.TryPeekNonTerminal(out var kind, out var node))
+        while (_stream.TryPeekNonTerminal(out var kind, out _))
         {
             // Check if it's one of the statement types we can reuse
-            var isStatement = kind switch
-            {
-                NodeKind.PrintStatement => true,
-                NodeKind.ReturnStatement => true,
-                NodeKind.FunctionDefinition => true,
-                NodeKind.AssignmentStatement => true,
-                NodeKind.ConditionalStatement => true,
-                NodeKind.LoopStatement => true,
-                _ => false
-            };
+            var isStatement = kind is NodeKind.PrintStatement
+                or NodeKind.ReturnStatement
+                or NodeKind.FunctionDefinition
+                or NodeKind.AssignmentStatement
+                or NodeKind.ConditionalStatement
+                or NodeKind.LoopStatement;
 
             if (isStatement)
             {
@@ -496,7 +499,10 @@ public sealed class Parser
                     statement = reused;
                     return true;
                 }
+                return false;
             }
+
+            _stream.Crumble();
         }
 
         return false;


### PR DESCRIPTION
- Shift statement list reuse into `Parser` and add `ISymbolStream.Crumble`.
- Remove `Blender` statement-list special casing
- Update docs.

Fixes #26